### PR TITLE
feat: raise minimum iOS deployment target to 16.4 (UD-16851)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "UnitComponents",
     platforms: [
-        .iOS(.v14)
+        .iOS("16.4")
     ],
     products: [
         .library(name: "UnitComponents", targets: ["UNComponentsSDKWrapperTarget"])

--- a/UnitComponents.podspec
+++ b/UnitComponents.podspec
@@ -12,12 +12,12 @@ Pod::Spec.new do |s|
   s.summary          = 'Unit Components SDK'
   s.description      = 'This SDK allows you to integrate Unit Components into your iOS app.'
 
-  s.platform         = :ios, '14.0'
+  s.platform         = :ios, '16.4'
   s.homepage         = 'https://guides.unit.co/white-label-ui'
   s.license          = { :type => 'Mozilla', :file => 'LICENSE' }
   s.author           = { 'Alon Shprung' => 'alonshp1@gmail.com' }
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '16.4'
 
   # Setting pod `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES`
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }


### PR DESCRIPTION
Web SDK 4.1+ requires WKWebView ≥ iOS 16.4 (constructable stylesheets). Aligns the distribution floors (podspec + Package.swift) with unit-ios-components #356.

Merge together with the SDK release that ships web 4.2 support.